### PR TITLE
[Perf] Avoid boxing on allocating a control's size

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/Page.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/Page.cs
@@ -98,7 +98,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
         {
             base.OnSizeAllocated(allocation);
 
-            if (!_lastAllocation.Equals(allocation))
+            if (_lastAllocation != allocation)
             {
                 _lastAllocation = allocation;
 


### PR DESCRIPTION
Gdk.Rectangle does not implement IEquatable<T>. Thus, the only equals method available is object.Equals(object). Sinc Gdk.Rectangle is a struct, this means that the parameter is boxed. Gtk# might implement IEquatable<T> for Gdk.Rectangle, although it can be considered. Until then, use the operator overload, as Equals defaults to going through operator==

### Description of Change ###

Optimize size allocation for a page

### Bugs Fixed ###

None

### API Changes ###

List all API changes here (or just put None), example:

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
