### PR TITLE
[Perf] Query fixed child's XY via allocation-less code

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Extensions/WidgetExtensions.cs
+++ b/Xamarin.Forms.Platform.GTK/Extensions/WidgetExtensions.cs
@@ -54,12 +54,26 @@ namespace Xamarin.Forms.Platform.GTK.Extensions
                 var calcX = (int)Math.Round(x);
                 var calcY = (int)Math.Round(y);
 
-                var containerChild = container[self] as Fixed.FixedChild;
+                int containerChildX, containerChildY;
+                GetContainerChildXY(container, self, out containerChildX, out containerChildY);
 
-                if (containerChild.X != calcX || containerChild.Y != calcY)
+                if (containerChildX != calcX || containerChildY != calcY)
                 {
                     container.Move(self, calcX, calcY);
                 }
+            }
+        }
+
+        static void GetContainerChildXY (Fixed parent, Widget child, out int x, out int y)
+        {
+            using (GLib.Value val = parent.ChildGetProperty(child, "x"))
+            {
+                x = (int)val;
+            }
+
+            using (GLib.Value val = parent.ChildGetProperty(child, "x"))
+            {
+                y = (int)val;
             }
         }
 


### PR DESCRIPTION
The previous code would wrap these two glib calls into a FixedChild class. That means extra overhead. This method is called a lot, so get rid of that overhead.

### Description of Change ###

Describe your changes here.

### Bugs Fixed ###

- Provide links to bugs here

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
