### PR TITLE
Let TabbedPageHeader to just be a HBox container

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/TabbedPageHeader.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/TabbedPageHeader.cs
@@ -3,32 +3,24 @@ using Gtk;
 
 namespace Xamarin.Forms.Platform.GTK.Controls
 {
-    public class TabbedPageHeader : EventBox
+    public class TabbedPageHeader : HBox
     {
         private Gtk.Label _label;
         private Gtk.Image _image;
 
         public TabbedPageHeader(string title, Pixbuf icon = null)
         {
-            HBox hbox = new HBox(false, 0);
-            hbox.Spacing = 0;
+            Spacing = 0;
 
             _image = new Gtk.Image();
             _image.Pixbuf = icon;
-            hbox.Add(_image);
+            Add(_image);
 
             _label = new Gtk.Label();
             _label.Text = title;
-            hbox.Add(_label);
+            Add(_label);
 
-            Add(hbox);
-
-            if ((Child != null))
-            {
-                Child.ShowAll();
-            }
-
-            Show();
+            ShowAll();
         }
 
         public Gtk.Label Label => _label;


### PR DESCRIPTION
### Description of Change ###

TabbedPageHeader is a HBox now, it has not to deal with its background

### Bugs Fixed ###

- Tab titles render a background color

### API Changes ###
None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
