### PR TITLE
Gtk remove animation running

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Forms.cs
+++ b/Xamarin.Forms.Platform.GTK/Forms.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Forms
             Device.SetIdiom(TargetIdiom.Desktop);
             Device.PlatformServices = new GtkPlatformServices();
             Device.Info = new GtkDeviceInfo();
+            Color.SetAccent(Color.FromHex("#3498DB"));
             ExpressionSearch.Default = new GtkExpressionSearch();
 
             Registrar.RegisterAll(new[]

--- a/Xamarin.Forms.Platform.GTK/Renderers/LayoutRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/LayoutRenderer.cs
@@ -35,11 +35,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
         {
             base.OnSizeAllocated(allocation);
 
-            if (IsAnimationRunning(Element))
-            {
-                return;
-            }
-
             if (_lastAllocation != allocation)
             {
                 _lastAllocation = allocation;
@@ -55,11 +50,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                     {
                         var renderer = Platform.GetRenderer(child);
                         renderer?.Container.SetSize(child.Bounds.Width, child.Bounds.Height);
-
-                        if (!IsAnimationRunning(renderer.Element))
-                        {
-                            renderer?.Container.MoveTo(child.Bounds.X, child.Bounds.Y);
-                        }
+                        renderer?.Container.MoveTo(child.Bounds.X, child.Bounds.Y);
                     }
                 }
             }

--- a/Xamarin.Forms.Platform.GTK/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ScrollViewRenderer.cs
@@ -61,11 +61,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
         {
             base.OnSizeAllocated(allocation);
 
-            if (IsAnimationRunning(Element))
-            {
-                return;
-            }
-
             if (_lastAllocation != allocation)
             {
                 _lastAllocation = allocation;
@@ -81,11 +76,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                     {
                         var renderer = Platform.GetRenderer(child);
                         renderer?.Container.SetSize(child.Bounds.Width, child.Bounds.Height);
-
-                        if (!IsAnimationRunning(renderer.Element))
-                        {
-                            renderer?.Container.MoveTo(child.Bounds.X, child.Bounds.Y);
-                        }
+                        renderer?.Container.MoveTo(child.Bounds.X, child.Bounds.Y);
                     }
                 }
             }

--- a/Xamarin.Forms.Platform.GTK/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/VisualElementRenderer.cs
@@ -227,21 +227,6 @@ namespace Xamarin.Forms.Platform.GTK
             UpdateSensitive();
         }
 
-        protected bool IsAnimationRunning(VisualElement element)
-        {
-            bool isAnimationRunning = false;
-
-            if (element.TranslationX != 0 ||
-                element.TranslationY != 0 ||
-                element.Rotation != 0 ||
-                element.RotationX != 0 ||
-                element.RotationY != 0 ||
-                element.Scale != 1)
-                isAnimationRunning = true;
-
-            return isAnimationRunning;
-        }
-
         private void UpdateIsVisible()
         {
             Container.Visible = Element.IsVisible;


### PR DESCRIPTION
### Description of Change ###

Removed IsAnimationRunning method

### Bugs Fixed ###

- Layout calcs are not applied when any transform property (scale, translation, etc) is established

### API Changes ###
None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
