### PR TITLE
Label positioning as Content of a ContentPage

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Renderers/LayoutRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/LayoutRenderer.cs
@@ -1,5 +1,4 @@
 ﻿using Gtk;
-using Xamarin.Forms.Platform.GTK.Extensions;
 using Xamarin.Forms.Platform.GTK.Packagers;
 
 namespace Xamarin.Forms.Platform.GTK.Renderers
@@ -8,7 +7,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
     {
         private Fixed _fixed;
         private LayoutElementPackager _packager;
-        private Gdk.Rectangle _lastAllocation;
 
         protected override void OnElementChanged(ElementChangedEventArgs<Layout> e)
         {
@@ -33,31 +31,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             }
 
             base.OnElementChanged(e);
-        }
-
-        protected override void OnSizeAllocated(Gdk.Rectangle allocation)
-        {
-            base.OnSizeAllocated(allocation);
-
-            if (_lastAllocation != allocation)
-            {
-                _lastAllocation = allocation;
-
-                Rectangle bounds = Element.Bounds;
-                Container.MoveTo((int)bounds.X, (int)bounds.Y);
-
-                for (var i = 0; i < ElementController.LogicalChildren.Count; i++)
-                {
-                    var child = ElementController.LogicalChildren[i] as VisualElement;
-
-                    if (child != null)
-                    {
-                        var renderer = Platform.GetRenderer(child);
-                        renderer?.Container.SetSize(child.Bounds.Width, child.Bounds.Height);
-                        renderer?.Container.MoveTo(child.Bounds.X, child.Bounds.Y);
-                    }
-                }
-            }
         }
     }
 }

--- a/Xamarin.Forms.Platform.GTK/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ScrollViewRenderer.cs
@@ -9,7 +9,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
     {
         private VisualElement _currentView;
         private Viewport _viewPort;
-        private Gdk.Rectangle _lastAllocation;
 
         protected IScrollViewController Controller
         {
@@ -54,31 +53,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 UpdateOrientation();
                 LoadContent();
                 UpdateContentSize();
-            }
-        }
-
-        protected override void OnSizeAllocated(Gdk.Rectangle allocation)
-        {
-            base.OnSizeAllocated(allocation);
-
-            if (_lastAllocation != allocation)
-            {
-                _lastAllocation = allocation;
-
-                Rectangle bounds = Element.Bounds;
-                Container.MoveTo((int)bounds.X, (int)bounds.Y);
-
-                for (var i = 0; i < ElementController.LogicalChildren.Count; i++)
-                {
-                    var child = ElementController.LogicalChildren[i] as VisualElement;
-
-                    if (child != null)
-                    {
-                        var renderer = Platform.GetRenderer(child);
-                        renderer?.Container.SetSize(child.Bounds.Width, child.Bounds.Height);
-                        renderer?.Container.MoveTo(child.Bounds.X, child.Bounds.Y);
-                    }
-                }
             }
         }
 

--- a/Xamarin.Forms.Platform.GTK/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/VisualElementRenderer.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Forms.Platform.GTK
         private VisualElementTracker<TElement, TNativeElement> _tracker;
         private string _defaultAccessibilityLabel;
         private string _defaultAccessibilityHint;
+        private Gdk.Rectangle _lastAllocation;
 
         protected VisualElementRenderer()
         {
@@ -133,6 +134,31 @@ namespace Xamarin.Forms.Platform.GTK
             base.Dispose();
 
             Dispose(true);
+        }
+
+        protected override void OnSizeAllocated(Gdk.Rectangle allocation)
+        {
+            base.OnSizeAllocated(allocation);
+
+            if (_lastAllocation != allocation)
+            {
+                _lastAllocation = allocation;
+
+                Rectangle bounds = Element.Bounds;
+                Container.MoveTo((int)bounds.X, (int)bounds.Y);
+
+                for (var i = 0; i < ElementController.LogicalChildren.Count; i++)
+                {
+                    var child = ElementController.LogicalChildren[i] as VisualElement;
+
+                    if (child != null)
+                    {
+                        var renderer = Platform.GetRenderer(child);
+                        renderer?.Container.SetSize(child.Bounds.Width, child.Bounds.Height);
+                        renderer?.Container.MoveTo(child.Bounds.X, child.Bounds.Y);
+                    }
+                }
+            }
         }
 
         protected virtual void OnRegisterEffect(PlatformEffect effect)


### PR DESCRIPTION
### Description of Change ###

Bounds positioning for OnSizeAllocated moved back to VisualElementRenderer

### Bugs Fixed ###

- Placing a layout as Content of a ContentPage works fine, but placing other VisualElements like a Label does not apply bounds positioning. For example, this code is not moving label to the center:

            return new ContentPage
            {
                Content = new Label
                {
                   Text = "Welcome to Xamarin Forms!",
                   VerticalOptions = LayoutOptions.Center,
                   HorizontalOptions = LayoutOptions.Center
                }
            };

### API Changes ###
None

### Behavioral Changes ###
None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
