### PR TITLE
Gtk Fix ListView double load in some situations

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/ListViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/ListViewCoreGalleryPage.cs
@@ -175,7 +175,7 @@ namespace Xamarin.Forms.Controls
 					new Employee ("Andrew 3", TimeSpan.FromDays (1000), 60),
 				};
 
-				Enumerable.Range(0, 900).Select(e => new Employee(e.ToString(), TimeSpan.FromDays(1), 60)).ForEach(e => Employees.Add(e));
+				Enumerable.Range(0, 9000).Select(e => new Employee(e.ToString(), TimeSpan.FromDays(1), 60)).ForEach(e => Employees.Add(e));
 			}
 		}
 

--- a/Xamarin.Forms.Controls/CoreGalleryPages/ListViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/ListViewCoreGalleryPage.cs
@@ -175,7 +175,7 @@ namespace Xamarin.Forms.Controls
 					new Employee ("Andrew 3", TimeSpan.FromDays (1000), 60),
 				};
 
-				Enumerable.Range(0, 9000).Select(e => new Employee(e.ToString(), TimeSpan.FromDays(1), 60)).ForEach(e => Employees.Add(e));
+				Enumerable.Range(0, 900).Select(e => new Employee(e.ToString(), TimeSpan.FromDays(1), 60)).ForEach(e => Employees.Add(e));
 			}
 		}
 

--- a/Xamarin.Forms.Platform.GTK/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ListViewRenderer.cs
@@ -74,9 +74,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
         {
             base.OnElementPropertyChanged(sender, e);
 
-            if (e.PropertyName == ListView.ItemsSourceProperty.PropertyName)
-                UpdateItems();
-            else if (e.PropertyName == ListView.IsGroupingEnabledProperty.PropertyName)
+            if (e.PropertyName == ListView.IsGroupingEnabledProperty.PropertyName)
                 UpdateGrouping();
             else if (e.PropertyName == nameof(ListView.HeaderElement))
                 UpdateHeader();


### PR DESCRIPTION
### Description of Change ###

Fix ListView double load in some situations.

### Bugs Fixed ###

- Fix ListView double load in some situations.

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
