### PR TITLE
Let page titles and icons to be changed on runtime

### DIFF
--- a/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
@@ -80,6 +80,43 @@ namespace Xamarin.Forms.Platform.GTK
             return Toolbar.Allocation.Size;
         }
 
+        public void UpdateIcon()
+        {
+            if (_toolbar == null || _navigation == null)
+                return;
+
+            var iconPath = GetCurrentPageIconPath();
+
+            if (!string.IsNullOrEmpty(iconPath))
+            {
+                _toolbarIcon.Pixbuf = new Pixbuf(iconPath);
+                _toolbarIcon.SetSizeRequest(GtkToolbarConstants.ToolbarIconWidth, GtkToolbarConstants.ToolbarIconHeight);
+            }
+            else
+            {
+                _toolbarIcon.WidthRequest = 1;
+            }
+        }
+
+        public void UpdateTitle()
+        {
+            if (_toolbar == null || _navigation == null)
+                return;
+
+            var title = GetCurrentPageTitle();
+
+            if (_toolbarTitle != null)
+            {
+                var span = new Span()
+                {
+                    FontSize = 12.0d,
+                    Text = title
+                };
+
+                _toolbarTitle.SetTextFromSpan(span);
+            }
+        }
+
         protected virtual HBox ConfigureToolbar()
         {
             var toolbar = new HBox();
@@ -121,49 +158,12 @@ namespace Xamarin.Forms.Platform.GTK
                 e.PropertyName.Equals(Page.IconProperty.PropertyName))
                 UpdateToolBar();
         }
-
-        private void UpdateTitle()
-        {
-            if (_toolbar == null || _navigation == null)
-                return;
-
-            var title = GetCurrentPageTitle();
-
-            if (_toolbarTitle != null)
-            {
-                var span = new Span()
-                {
-                    FontSize = 12.0d,
-                    Text = title
-                };
-
-                _toolbarTitle.SetTextFromSpan(span);
-            }
-        }
-
+        
         private string GetCurrentPageTitle()
         {
             if (_navigation == null)
                 return string.Empty;
             return _navigation.Peek(0).Title ?? string.Empty;
-        }
-
-        private void UpdateIcon()
-        {
-            if (_toolbar == null || _navigation == null)
-                return;
-
-            var iconPath = GetCurrentPageIconPath();
-
-            if (!string.IsNullOrEmpty(iconPath))
-            {
-                _toolbarIcon.Pixbuf = new Pixbuf(iconPath);
-                _toolbarIcon.SetSizeRequest(GtkToolbarConstants.ToolbarIconWidth, GtkToolbarConstants.ToolbarIconHeight);
-            }
-            else
-            {
-                _toolbarIcon.WidthRequest = 1;
-            }
         }
 
         private string GetCurrentPageIconPath()

--- a/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
@@ -206,6 +206,10 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 UpdateBackgroundColor();
             else if (e.PropertyName == Xamarin.Forms.Page.BackgroundImageProperty.PropertyName)
                 UpdateBackgroundImage();
+            else if (e.PropertyName == Xamarin.Forms.Page.TitleProperty.PropertyName)
+                UpdateTitle();
+            else if (e.PropertyName == Xamarin.Forms.Page.IconProperty.PropertyName)
+                UpdateIcon();
         }
 
         private void SetPageSize(int width, int height)
@@ -213,6 +217,16 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             var toolbarSize = Platform.NativeToolbarTracker.GetCurrentToolbarSize();
             var pageContentSize = new Gdk.Rectangle(0, 0, width, height - toolbarSize.Height);
             SetElementSize(pageContentSize.ToSize());
+        }
+
+        private void UpdateTitle()
+        {
+            Platform.NativeToolbarTracker.UpdateToolBar();
+        }
+
+        private void UpdateIcon()
+        {
+            Platform.NativeToolbarTracker.UpdateToolBar();
         }
     }
 }

--- a/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
@@ -221,12 +221,12 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
         private void UpdateTitle()
         {
-            Platform.NativeToolbarTracker.UpdateToolBar();
+            Platform.NativeToolbarTracker.UpdateTitle();
         }
 
         private void UpdateIcon()
         {
-            Platform.NativeToolbarTracker.UpdateToolBar();
+            Platform.NativeToolbarTracker.UpdateIcon();
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

These changes let page titles and icons to be changed on runtime.

### Bugs Fixed ###

- Toolbar title and icon were not refreshing when they are changed in runtime.

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
