### PR TITLE
Protection of GTK Label null text

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Cells/EntryCell.cs
+++ b/Xamarin.Forms.Platform.GTK/Cells/EntryCell.cs
@@ -25,15 +25,15 @@ namespace Xamarin.Forms.Platform.GTK.Cells
 
             _textLabel = new Gtk.Label();
             _textLabel.SetAlignment(0, 0);
-            _textLabel.Text = label;
+            _textLabel.Text = label ?? string.Empty;
             _textLabel.ModifyFg(StateType.Normal, labelColor);
 
             _root.PackStart(_textLabel, false, false, 0);
 
             _entryWrapper = new EntryWrapper();
             _entryWrapper.Sensitive = true;
-            _entryWrapper.Entry.Text = text;
-            _entryWrapper.PlaceholderText = placeholder;
+            _entryWrapper.Entry.Text = text ?? string.Empty;
+            _entryWrapper.PlaceholderText = placeholder ?? string.Empty;
             _entryWrapper.Entry.Changed += OnEntryChanged;
             _entryWrapper.Entry.EditingDone += OnEditingDone;
 
@@ -71,7 +71,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
         {
             if (_textLabel != null)
             {
-                _textLabel.Text = label;
+                _textLabel.Text = label ?? string.Empty;
             }
         }
 
@@ -87,7 +87,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
         {
             if (_entryWrapper != null)
             {
-                _entryWrapper.Entry.Text = text;
+                _entryWrapper.Entry.Text = text ?? string.Empty;
             }
         }
 
@@ -95,7 +95,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
         {
             if (_entryWrapper != null)
             {
-                _entryWrapper.PlaceholderText = placeholder;
+                _entryWrapper.PlaceholderText = placeholder ?? string.Empty;
             }
         }
 

--- a/Xamarin.Forms.Platform.GTK/Cells/EntryCellRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Cells/EntryCellRenderer.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
 
             var label = entryCell.Label ?? string.Empty;
             var labelColor = entryCell.LabelColor.ToGtkColor();
-            var text = entryCell.Text;
+            var text = entryCell.Text ?? string.Empty;
             var placeholder = entryCell.Placeholder;
 
             return new EntryCell(
@@ -51,7 +51,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
             }
             else if (args.PropertyName == Xamarin.Forms.EntryCell.TextProperty.PropertyName)
             {
-                gtkEntryCell.Text = entryCell.Text;
+                gtkEntryCell.Text = entryCell.Text ?? string.Empty;
             }
             else if (args.PropertyName == Xamarin.Forms.EntryCell.PlaceholderProperty.PropertyName)
             {
@@ -61,7 +61,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
 
         private void OnTextChanged(object sender, string text)
         {
-            ((Xamarin.Forms.EntryCell)Cell).Text = text;
+            ((Xamarin.Forms.EntryCell)Cell).Text = text ?? string.Empty;
         }
 
         private void OnEditingDone(object sender, EventArgs e)

--- a/Xamarin.Forms.Platform.GTK/Cells/ImageCell.cs
+++ b/Xamarin.Forms.Platform.GTK/Cells/ImageCell.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
             var span = new Span()
             {
                 FontSize = 12,
-                Text = text
+                Text = text ?? string.Empty
             };
 
             _textLabel = new Gtk.Label();
@@ -49,7 +49,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
             _detailLabel = new Gtk.Label();
             _detailLabel.SetAlignment(0, 0);
             _detailLabel.ModifyFg(StateType.Normal, detailColor);
-            _detailLabel.Text = detail;
+            _detailLabel.Text = detail ?? string.Empty;
 
             _vertical.PackStart(_detailLabel, true, true, 0);
 
@@ -98,7 +98,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
         {
             if (_textLabel != null)
             {
-                _textLabel.Text = text;
+                _textLabel.Text = text ?? string.Empty;
             }
         }
 
@@ -106,7 +106,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
         {
             if (_detailLabel != null)
             {
-                _detailLabel.Text = detail;
+                _detailLabel.Text = detail ?? string.Empty;
             }
         }
 

--- a/Xamarin.Forms.Platform.GTK/Cells/SwitchCell.cs
+++ b/Xamarin.Forms.Platform.GTK/Cells/SwitchCell.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
 
             _textLabel = new Gtk.Label();
             _textLabel.SetAlignment(0, 0);
-            _textLabel.Text = text;
+            _textLabel.Text = text ?? string.Empty;
 
             _labelBox.PackStart(_textLabel, false, true, 0);
 
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
         {
             if (_textLabel != null)
             {
-                _textLabel.Text = text;
+                _textLabel.Text = text ?? string.Empty;
             }
         }
 

--- a/Xamarin.Forms.Platform.GTK/Cells/TextCell.cs
+++ b/Xamarin.Forms.Platform.GTK/Cells/TextCell.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
             var span = new Span()
             {
                 FontSize = 12,
-                Text = text
+                Text = text ?? string.Empty
             };
 
             _textLabel = new Gtk.Label();
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
             _detailLabel = new Gtk.Label();
             _detailLabel.SetAlignment(0, 0);
             _detailLabel.ModifyFg(StateType.Normal, detailColor);
-            _detailLabel.Text = detail;
+            _detailLabel.Text = detail ?? string.Empty;
 
             _root.PackStart(_detailLabel, true, true, 0);
 
@@ -86,7 +86,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
         {
             if(_textLabel != null)
             {
-                _textLabel.Text = text;
+                _textLabel.Text = text ?? string.Empty;
             }
         }
 
@@ -94,7 +94,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
         {
             if (_detailLabel != null)
             {
-                _detailLabel.Text = detail;
+                _detailLabel.Text = detail ?? string.Empty;
             }
         }
 
@@ -121,7 +121,7 @@ namespace Xamarin.Forms.Platform.GTK.Cells
                 var span = new Span()
                 {
                     FontSize = isGroupHeader ? 18 : 12,
-                    Text = _textLabel.Text
+                    Text = _textLabel.Text ?? string.Empty
                 };
 
                 _textLabel.SetTextFromSpan(span);

--- a/Xamarin.Forms.Platform.GTK/Controls/EntryWrapper.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/EntryWrapper.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
             }
             set
             {
-                _placeholder.Text = value;
+                _placeholder.Text = value ?? string.Empty;
             }
         }
 

--- a/Xamarin.Forms.Platform.GTK/Controls/MasterDetailPage.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/MasterDetailPage.cs
@@ -118,7 +118,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 
             set
             {
-                _titleContainer.Title = value;
+                _titleContainer.Title = value ?? string.Empty;
             }
         }
 

--- a/Xamarin.Forms.Platform.GTK/Controls/NotebookWrapper.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/NotebookWrapper.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 
         public void InsertPage(Widget container, string title, Pixbuf icon, int position)
         {
-            var header = new TabbedPageHeader(title, icon);
+            var header = new TabbedPageHeader(title ?? string.Empty, icon);
             container.Unparent();
 
             var wrapper = new NotebookPageWrapper(container);
@@ -97,7 +97,9 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 
         public void SetBackgroundImage(string backgroundImagePath)
         {
-            _backgroundPixbuf = new Pixbuf(backgroundImagePath);
+            _backgroundPixbuf = !string.IsNullOrEmpty(backgroundImagePath)
+                ? new Pixbuf(backgroundImagePath)
+                : null;
 
             for (int i = 0; i < _noteBook.NPages; i++)
             {

--- a/Xamarin.Forms.Platform.GTK/Controls/SearchEntry.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/SearchEntry.cs
@@ -50,7 +50,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
             }
             set
             {
-                _entryWrapper.Entry.Text = value;
+                _entryWrapper.Entry.Text = value ?? string.Empty;
             }
         }
 
@@ -62,7 +62,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
             }
             set
             {
-                _entryWrapper.PlaceholderText = value;
+                _entryWrapper.PlaceholderText = value ?? string.Empty;
             }
         }
 

--- a/Xamarin.Forms.Platform.GTK/Controls/TabbedPageHeader.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/TabbedPageHeader.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
             Add(_image);
 
             _label = new Gtk.Label();
-            _label.Text = title;
+            _label.Text = title ?? string.Empty;
             Add(_label);
 
             ShowAll();

--- a/Xamarin.Forms.Platform.GTK/Controls/TableView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/TableView.cs
@@ -117,7 +117,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
                 var titleSpan = new Span()
                 {
                     FontSize = 16,
-                    Text = source.Title
+                    Text = source.Title ?? string.Empty
                 };
 
                 Gtk.Label title = new Gtk.Label();
@@ -136,7 +136,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
                     var tableSectionSpan = new Span()
                     {
                         FontSize = 12,
-                        Text = tableSection.Title
+                        Text = tableSection.Title ?? string.Empty
                     };
 
                     // Table Section Title

--- a/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
@@ -110,7 +110,7 @@ namespace Xamarin.Forms.Platform.GTK
                 var span = new Span()
                 {
                     FontSize = 12.0d,
-                    Text = title
+                    Text = title ?? string.Empty
                 };
 
                 _toolbarTitle.SetTextFromSpan(span);
@@ -451,7 +451,7 @@ namespace Xamarin.Forms.Platform.GTK
                 Gtk.Image icon = pixBuf != null ? new Gtk.Image(pixBuf) : null;
                 ToolButton button = new ToolButton(icon, item.Text);
                 ApplyDefaultDimensions(button);
-                button.TooltipText = item.Text;
+                button.TooltipText = item.Text ?? string.Empty;
                 button.Sensitive = item.IsEnabled;
 
                 return button;

--- a/Xamarin.Forms.Platform.GTK/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ButtonRenderer.cs
@@ -125,7 +125,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 FontAttributes = Element.FontAttributes,
                 FontFamily = Element.FontFamily,
                 FontSize = Element.FontSize,
-                Text = Element.Text
+                Text = Element.Text ?? string.Empty
             };
 
             Control.LabelWidget.SetTextFromSpan(span);

--- a/Xamarin.Forms.Platform.GTK/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/EntryRenderer.cs
@@ -120,7 +120,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
         private void UpdatePlaceholder()
         {
-            Control.PlaceholderText = Element.Placeholder;
+            Control.PlaceholderText = Element.Placeholder ?? string.Empty;
             Control.SetPlaceholderTextColor(Element.PlaceholderColor.ToGtkColor());
         }
 

--- a/Xamarin.Forms.Platform.GTK/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/LabelRenderer.cs
@@ -81,7 +81,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                     FontAttributes = Element.FontAttributes,
                     FontFamily = Element.FontFamily,
                     FontSize = Element.FontSize,
-                    Text = Element.Text
+                    Text = Element.Text ?? string.Empty
                 };
 
                 Control.SetTextFromSpan(span);

--- a/Xamarin.Forms.Platform.GTK/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/SearchBarRenderer.cs
@@ -89,7 +89,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
         private void UpdatePlaceholder()
         {
-            Control.PlaceholderText = Element.Placeholder;
+            Control.PlaceholderText = Element.Placeholder ?? string.Empty;
             Control.SetPlaceholderTextColor(Element.PlaceholderColor.ToGtkColor());
         }
 

--- a/Xamarin.Forms.Platform.GTK/Renderers/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/TabbedPageRenderer.cs
@@ -178,7 +178,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             {
                 var page = (Page)sender;
                 var index = TabbedPage.GetIndex(page);
-                var title = page.Title;
 
                 Widget.SetTabLabelText(index, page.Title);
             }


### PR DESCRIPTION
Avoid any GTK critical messages when setting a null string to a GTK Label text

### Description of Change ###

Protection code

### Bugs Fixed ###

- Some GTK critical messages prevented

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
