### PR TITLE
Fixed Picker async loading

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/PickerRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using Gtk;
 using System.ComponentModel;
 using System.Linq;
+using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.GTK.Extensions;
 
 namespace Xamarin.Forms.Platform.GTK.Renderers
@@ -23,6 +24,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                     comboBox.Focused += OnFocused;
                     comboBox.FocusOutEvent += OnFocusOutEvent;
                     comboBox.Changed += OnChanged;
+
+                    ((LockableObservableListWrapper)Element.Items)._list.CollectionChanged += OnCollectionChanged;
 
                     SetNativeControl(comboBox);
                 }
@@ -64,6 +67,11 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                         Control.Changed -= OnChanged;
                     }
 
+                    if(Element != null)
+                    {
+                        ((LockableObservableListWrapper)Element.Items)._list.CollectionChanged -= OnCollectionChanged;
+                    }
+
                 }
             }
 
@@ -87,8 +95,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
         private void UpdateItemsSource()
         {
-            var items = Element.Items;
-
+            var items = ((LockableObservableListWrapper)Element.Items)._list;
             ListStore listStore = new ListStore(typeof(string));
             Control.Model = listStore;
 
@@ -138,6 +145,11 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
         private void OnChanged(object sender, System.EventArgs e)
         {
             ElementController?.SetValueFromRenderer(Picker.SelectedIndexProperty, Control.Active);
+        }
+
+        private void OnCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            UpdateItemsSource();
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

The Picker dont load anything if the loading process is async.

### Bugs Fixed ###

- Fixed Picker async loading.

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
