### PR TITLE
TemplatedTabbedGallery: fix move page

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ScrollViewRenderer.cs
@@ -125,6 +125,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             if (_currentView != null)
             {
                 renderer = _currentView.GetOrCreateRenderer();
+                renderer.Container.Unparent();
             }
 
             if (renderer != null)

--- a/Xamarin.Forms.Platform.GTK/Renderers/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/TabbedPageRenderer.cs
@@ -45,10 +45,11 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             }
 
             OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
-
             OnPagesChanged(Page.Children,
                 new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 
+            Page.ChildAdded += OnPageAdded;
+            Page.ChildRemoved += OnPageRemoved;
             Page.PropertyChanged += OnElementPropertyChanged;
             Page.PagesChanged += OnPagesChanged;
 
@@ -86,6 +87,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
         protected override void Dispose(bool disposing)
         {
             Page.PagesChanged -= OnPagesChanged;
+            Page.ChildAdded -= OnPageAdded;
+            Page.ChildRemoved -= OnPageRemoved;
 
             if (Widget != null)
             {
@@ -99,59 +102,49 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
         {
             Widget.NoteBook.SwitchPage -= OnNotebookPageSwitched;
 
-            e.Apply((o, i, c) => SetupPage((Page)o, i), (o, i) => TeardownPage((Page)o), Reset);
-            ResetPages();
-            SetPages();
+            if (e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                ResetPages();
+            }
+
             UpdateChildrenOrderIndex();
             UpdateCurrentPage();
 
             Widget.NoteBook.SwitchPage += OnNotebookPageSwitched;
         }
 
-        private void SetupPage(Page page, int index)
+        private void OnPageAdded(object sender, ElementEventArgs e)
         {
-            var renderer = Platform.GetRenderer(page);
+            InsertPage(e.Element as Page, Page.Children.IndexOf(e.Element));
+        }
 
-            if (renderer == null)
+        private void OnPageRemoved(object sender, ElementEventArgs e)
+        {
+            RemovePage(e.Element as Page);
+        }
+
+        private void InsertPage(Page page, int index)
+        {
+            var pageRenderer = Platform.GetRenderer(page);
+
+            if (pageRenderer == null)
             {
-                renderer = Platform.CreateRenderer(page);
-                Platform.SetRenderer(page, renderer);
+                pageRenderer = Platform.CreateRenderer(page);
+                Platform.SetRenderer(page, pageRenderer);
             }
+
+            Widget.InsertPage(
+                pageRenderer.Container,
+                page.Title,
+                page.Icon?.ToPixbuf(new Size(DefaultIconWidth, DefaultIconHeight)),
+                index);
+
+            Widget.ShowAll();
 
             page.PropertyChanged += OnPagePropertyChanged;
         }
 
-        private void ResetPages()
-        {
-            Widget.RemoveAllPages();
-        }
-
-        private void SetPages()
-        {
-            for (var i = 0; i < Page.Children.Count; i++)
-            {
-                var child = Page.Children[i];
-                var page = child as Page;
-
-                if (page == null)
-                    continue;
-
-                var pageRenderer = Platform.GetRenderer(page);
-
-                if (pageRenderer != null)
-                {
-                    Widget.InsertPage(
-                        pageRenderer.Container,
-                        page.Title,
-                        page.Icon?.ToPixbuf(new Size(DefaultIconWidth, DefaultIconHeight)),
-                        i);
-                }
-            }
-
-            Widget.ShowAll();
-        }
-
-        private void TeardownPage(Page page)
+        private void RemovePage(Page page)
         {
             page.PropertyChanged -= OnPagePropertyChanged;
 
@@ -165,11 +158,16 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             Platform.SetRenderer(page, null);
         }
 
-        private void Reset()
+        private void ResetPages()
         {
+            foreach (var page in Page.Children)
+                RemovePage(page);
+
+            Widget.RemoveAllPages();
+
             var i = 0;
             foreach (var page in Page.Children)
-                SetupPage(page, i++);
+                InsertPage(page, i++);
         }
 
         private void OnPagePropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

Moving page management to Add and Remove events of Tabbed Page.

### Bugs Fixed ###

- Move tab from TemplatedTabbedGallery resulted in empty page, and some empties detected when adding multiple pages.

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
