### PR TITLE
Gtk CarouselPage CurrentPage

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/Carousel.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/Carousel.cs
@@ -8,6 +8,24 @@ using Xamarin.Forms.Platform.GTK.Extensions;
 
 namespace Xamarin.Forms.Platform.GTK.Controls
 {
+    public class CarouselEventArgs : EventArgs
+    {
+        private int _selectedIndex;
+
+        public int SelectedIndex
+        {
+            get
+            {
+                return _selectedIndex;
+            }
+        }
+
+        public CarouselEventArgs(int selectedIndex)
+        {
+            _selectedIndex = selectedIndex;
+        }
+    }
+
     public class CarouselPage
     {
         public Container GtkPage { get; set; }
@@ -33,6 +51,10 @@ namespace Xamarin.Forms.Platform.GTK.Controls
         private double _initialPos;
         private bool _animated;
 
+        public delegate void EventHandler(object sender, CarouselEventArgs args);
+
+        public event EventHandler SelectedIndexChanged;
+
         public Carousel()
         {
             BuildCarousel();
@@ -57,13 +79,22 @@ namespace Xamarin.Forms.Platform.GTK.Controls
         public int SelectedIndex
         {
             get { return _selectedIndex; }
-            private set { _selectedIndex = value; }
+            private set
+            {
+                _selectedIndex = value;
+                SelectedIndexChanged?.Invoke(this, new CarouselEventArgs(_selectedIndex));
+            }
         }
 
         public bool Animated
         {
             get { return _animated; }
             set { _animated = value; }
+        }
+
+        public List<CarouselPage> Pages
+        {
+            get { return _pages; }
         }
 
         public void SetBackground(Gdk.Color backgroundColor)

--- a/Xamarin.Forms.Platform.GTK/Renderers/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/CarouselPageRenderer.cs
@@ -36,7 +36,13 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
             if (Page != null)
             {
+                Page.PropertyChanged -= OnPagePropertyChanged;
                 Page.PagesChanged -= OnPagesChanged;
+            }
+
+            if(Widget != null)
+            {
+                Widget.SelectedIndexChanged -= OnSelectedIndexChanged;
             }
         }
 
@@ -58,6 +64,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 {
                     Widget = new Carousel();
                     Widget.Animated = true;
+
+                    Widget.SelectedIndexChanged += OnSelectedIndexChanged;
 
                     var eventBox = new EventBox();
                     eventBox.Add(Widget);
@@ -85,6 +93,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             UpdateBackgroundColor();
             UpdateBackgroundImage();
 
+            Page.PropertyChanged += OnPagePropertyChanged;
             Page.PagesChanged += OnPagesChanged;
         }
 
@@ -110,6 +119,12 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
         protected override void UpdateBackgroundImage()
         {
             Widget?.SetBackgroundImage(Page.BackgroundImage);
+        }
+
+        private void OnPagePropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(TabbedPage.CurrentPage))
+                UpdateCurrentPage();
         }
 
         private void OnPagesChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -199,6 +214,25 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             }
 
             UpdateCurrentPage();
+        }
+
+        private void OnSelectedIndexChanged(object sender, CarouselEventArgs args)
+        {
+            var selectedIndex = args.SelectedIndex;
+            var widgetPage = Widget.Pages[selectedIndex];
+            var page = widgetPage.Page as ContentPage;
+
+            if (page == null)
+                return;
+
+            if (((CarouselPage)Element).CurrentPage == page)
+                return;
+
+            ContentPage currentPage = page;
+
+            currentPage?.SendDisappearing();
+            ((CarouselPage)Element).CurrentPage = page;
+            page?.SendAppearing();
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

Fixed bug related to CarouselPage CurrentPage.

### Bugs Fixed ###

- Fixed a problem related to CarouselPage CurrentPage property. Sometimes, setting the property nothing happens.

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
