### PR TITLE
BoxView Color and use of default values

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/BoxView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/BoxView.cs
@@ -24,6 +24,11 @@ namespace Xamarin.Forms.Platform.GTK.Controls
             }
         }
 
+        public void ResetColor()
+        {
+            UpdateColor(Gdk.Color.Zero);
+        }
+
         public void UpdateBackgroundColor(Gdk.Color color)
         {
             if (_boxView != null)
@@ -123,6 +128,8 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 
         private void DrawBoxView(Context cr, EventExpose ev)
         {
+            if (Color.Equal(Gdk.Color.Zero)) return;
+
             int clipHeight = ev.Area.Height > 0 ? Height : 0;
             int clipWidth = ev.Area.Width > 0 ? Width : 0;
 

--- a/Xamarin.Forms.Platform.GTK/Renderers/BoxViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/BoxViewRenderer.cs
@@ -56,9 +56,15 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             if (Element == null || Control == null)
                 return;
 
-            var backgroundColor = color != Color.Default ? color : Color.Transparent;
-
-            Control.UpdateColor(backgroundColor.ToGtkColor());
+            if (color.IsDefaultOrTransparent())
+            {
+                Control.ResetColor();
+            }
+            else
+            {
+                var backgroundColor = color.ToGtkColor();
+                Control.UpdateColor(backgroundColor);
+            }
         }
 
         private void SetSize()


### PR DESCRIPTION
### Description of Change ###

BoxView default color should not apply internal DrawingArea stuff.

### Bugs Fixed ###

- Setting BackgroundColor to a given color and making Color property to be Transparent or Default, just makes BackgroundColor not to be drawn.

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
