### PR TITLE
CarouselPage and initial pages visibility

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/Carousel.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/Carousel.cs
@@ -128,6 +128,8 @@ namespace Xamarin.Forms.Platform.GTK.Controls
             if (page != null)
             {
                 var gtkPage = Platform.CreateRenderer(page);
+                gtkPage.Container.Shown += OnChildPageShown;
+
                 _pages.Insert(index, new CarouselPage(gtkPage.Container, page));
                 _root.Attach(gtkPage.Container, 0, 1, 0, 1);
             }
@@ -142,9 +144,10 @@ namespace Xamarin.Forms.Platform.GTK.Controls
             if (page != null)
             {
                 var gtkPage = _pages.FirstOrDefault(p => p.Page == page);
-
+                
                 if (gtkPage != null)
                 {
+                    gtkPage.GtkPage.Shown -= OnChildPageShown;
                     _pages.Remove(gtkPage);
                     _root.RemoveFromContainer(gtkPage.GtkPage);
                 }
@@ -155,6 +158,11 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 
         public void Reset()
         {
+            foreach (var page in _pages)
+            {
+                page.GtkPage.Shown -= OnChildPageShown;
+            }
+
             _pages.Clear();
 
             do
@@ -181,16 +189,6 @@ namespace Xamarin.Forms.Platform.GTK.Controls
             {
                 Internals.Log.Warning("CarouselPage BackgroundImage", "Could not load background image: {0}", ex);
             }
-        }
-
-        protected override bool OnExposeEvent(EventExpose evnt)
-        {
-            if (_pages.Count(p => p.GtkPage.Visible) > 1)
-            {
-                SetCurrentPage(SelectedIndex);
-            }
-
-            return base.OnExposeEvent(evnt);
         }
 
         protected override void OnSizeAllocated(Gdk.Rectangle allocation)
@@ -264,6 +262,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
                 {
                     var page = pageContainer.Page;
                     var gtkPage = Platform.CreateRenderer(page);
+                    gtkPage.Container.Shown += OnChildPageShown;
 
                     _pages.Add(new CarouselPage(gtkPage.Container, page));
                     _root.Attach(gtkPage.Container, 0, 1, 0, 1);
@@ -295,6 +294,11 @@ namespace Xamarin.Forms.Platform.GTK.Controls
             
             SelectedIndex++;
 
+            SetCurrentPage(SelectedIndex);
+        }
+
+        private void OnChildPageShown(object sender, EventArgs e)
+        {
             SetCurrentPage(SelectedIndex);
         }
     }

--- a/Xamarin.Forms.Platform.GTK/Renderers/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/CarouselPageRenderer.cs
@@ -65,8 +65,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                     Widget = new Carousel();
                     Widget.Animated = true;
 
-                    Widget.SelectedIndexChanged += OnSelectedIndexChanged;
-
                     var eventBox = new EventBox();
                     eventBox.Add(Widget);
                     Control.Content = eventBox;
@@ -80,7 +78,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
             if (newPage != null)
             {
-                UpdateCurrentPage();
                 newPage.SendAppearing();
             }
 
@@ -195,6 +192,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
         private void UpdateSource()
         {
+            Widget.SelectedIndexChanged -= OnSelectedIndexChanged;
+
             _pages = new List<PageContainer>();
 
             for (var i = 0; i < Element.LogicalChildren.Count; i++)
@@ -214,6 +213,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             }
 
             UpdateCurrentPage();
+
+            Widget.SelectedIndexChanged += OnSelectedIndexChanged;
         }
 
         private void OnSelectedIndexChanged(object sender, CarouselEventArgs args)


### PR DESCRIPTION
### Description of Change ###

On CarouselPage, initial CurrentPage was always first one, even if this should be any other from Pages source. Furthermore, as NavigationPage makes a ShowAll, all Carousel control pages where Visible = true when shown on first time.

### Bugs Fixed ###

- First page always appears as Visible, even if it's not desired CurrentPage of CarouselPage.
- When a parent widget applies a ShowAll, all pages were marked as Visible (when only one of them, CurrentPage, should).

### API Changes ###

None.

### Behavioral Changes ###

None.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
