### PR TITLE
Fix listview selection index

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ListViewRenderer.cs
@@ -501,20 +501,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 return;
 
             var templatedItems = TemplatedItemsView.TemplatedItems;
-            var index = -1;
-
-            if (Element.IsGroupingEnabled)
-            {
-                int selectedItemIndex = templatedItems.GetGlobalIndexOfItem(args.Item);
-                var leftOver = 0;
-                int groupIndex = templatedItems.GetGroupIndexFromGlobal(selectedItemIndex, out leftOver);
-
-                index = selectedItemIndex - (groupIndex + 1);
-            }
-            else
-            {
-                index = templatedItems.GetGlobalIndexOfItem(args.Item);
-            }
+            var index = templatedItems.GetGlobalIndexOfItem(args.Item);
 
             if (index > -1)
             {


### PR DESCRIPTION
### Description of Change ###
Changed index selection calcs, delegating to NotifyRowTapped

### Bugs Fixed ###

- On grouped lists, there is a crash when selecting a row

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
