### PR TITLE
Grab focus on some custom widgets

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/EntryWrapper.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/EntryWrapper.cs
@@ -84,6 +84,11 @@ namespace Xamarin.Forms.Platform.GTK.Controls
             ShowPlaceholderIfNeeded();
         }
 
+        protected override void OnFocusGrabbed()
+        {
+            _entry?.GrabFocus();
+        }
+
         private void ShowPlaceholderIfNeeded()
         {
             if (string.IsNullOrEmpty(_entry.Text) && !string.IsNullOrEmpty(_placeholder.Text))

--- a/Xamarin.Forms.Platform.GTK/Controls/ImageButton.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/ImageButton.cs
@@ -26,7 +26,6 @@ namespace Xamarin.Forms.Platform.GTK.Controls
             _defaultBorderColor = Style.BaseColors[(int)StateType.Active];
 
             Relief = ReliefStyle.None;
-            CanFocus = false;
 
             _image = new Gtk.Image();
             _label = new Gtk.Label();

--- a/Xamarin.Forms.Platform.GTK/Controls/ScrolledTextView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/ScrolledTextView.cs
@@ -22,5 +22,10 @@ namespace Xamarin.Forms.Platform.GTK.Controls
         }
 
         public TextView TextView => _textView;
+
+        protected override void OnFocusGrabbed()
+        {
+            _textView?.GrabFocus();
+        }
     }
 }

--- a/Xamarin.Forms.Platform.GTK/Controls/SearchEntry.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/SearchEntry.cs
@@ -155,6 +155,11 @@ namespace Xamarin.Forms.Platform.GTK.Controls
             _entryWrapper.SetAlignment(alignmentValue);
         }
 
+        protected override void OnFocusGrabbed()
+        {
+            _entryWrapper?.GrabFocus();
+        }
+
         private void ShowClearButton()
         {
             if (_clearButton.Parent == null)


### PR DESCRIPTION
### Description of Change ###

Some custom widgets should propagate their focus to one of their children when required

### Bugs Fixed ###

- XF bug B31333 was not correctly working (focus mapping of some controls)

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
