### PR TITLE
Dispose overflow for MasterDetailPage

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/MasterDetailPage.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/MasterDetailPage.cs
@@ -213,17 +213,26 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 
         private void RefreshMasterBehavior(MasterBehaviorType masterBehaviorType)
         {
+            int detailWidthRequest = 0;
+            Gdk.Point point = default(Gdk.Point);
+
             switch (_masterBehaviorType)
             {
                 case MasterBehaviorType.Split:
-                    _detail.WidthRequest = _lastAllocation.Width - DefaultMasterWidth;
-                    _detail.MoveTo(_master.WidthRequest, 0);
+                    detailWidthRequest = _lastAllocation.Width - DefaultMasterWidth;
+                    point = new Gdk.Point(_master.WidthRequest, 0);
                     break;
                 case MasterBehaviorType.Default:
                 case MasterBehaviorType.Popover:
-                    _detail.WidthRequest = _lastAllocation.Width;
-                    _detail.MoveTo(0, 0);
+                    detailWidthRequest = _lastAllocation.Width;
+                    point = new Gdk.Point(0, 0);
                     break;
+            }
+
+            if (detailWidthRequest >= 0)
+            {
+                _detail.WidthRequest = detailWidthRequest;
+                _detail.MoveTo(point.X, point.Y);
             }
         }
 

--- a/Xamarin.Forms.Platform.GTK/Renderers/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/MasterDetailPageRenderer.cs
@@ -88,7 +88,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 Page.Master.PropertyChanged -= HandleMasterPropertyChanged;
             }
 
-            base.Dispose();
+            base.Dispose(disposing);
         }
 
         protected override async void OnElementChanged(VisualElementChangedEventArgs e)

--- a/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
@@ -120,7 +120,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             Platform.NativeToolbarTracker.TryHide(Element as NavigationPage);
             _appeared = false;
 
-            PageController.SendDisappearing();
+            PageController?.SendDisappearing();
 
             base.OnDestroyed();
         }


### PR DESCRIPTION
### Description of Change ###

Dispose overflow detected and removing negative width request warnings for MasterDetailPage.

### Bugs Fixed ###

- On B31255 a stack overflow is detected when disposing MasterDetailPage
- Some width request errors detected on GTK output

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
