### PR TITLE
Mapped selected area and zoom enable/disable property

### DIFF
--- a/GMap.NET.GTK/GMapControl.cs
+++ b/GMap.NET.GTK/GMapControl.cs
@@ -730,7 +730,7 @@
 
         protected override bool OnExposeEvent(Gdk.EventExpose e)
         {
-            Console.WriteLine(String.Format("Tread: {0}", System.Threading.Thread.CurrentThread.ManagedThreadId));
+            Console.WriteLine(String.Format("Tread: {0}", Thread.CurrentThread.ManagedThreadId));
             if (ForceDoubleBuffer)
             {
                 if (_gxOff != null)
@@ -989,7 +989,7 @@
                 g.ResetTransform();
             }
 
-            if (!SelectedArea.IsEmpty)
+            if (!SelectedArea.IsEmpty && MouseWheelZoomEnabled)
             {
                 GPoint p1 = FromLatLngToLocal(SelectedArea.LocationTopLeft);
                 GPoint p2 = FromLatLngToLocal(SelectedArea.LocationRightBottom);
@@ -1143,7 +1143,7 @@
         protected override void OnSizeAllocated(Gdk.Rectangle box)
         {
             base.OnSizeAllocated(box);
-            Console.WriteLine(string.Format("Allocation Tread: {0}", System.Threading.Thread.CurrentThread.ManagedThreadId));
+            Console.WriteLine(string.Format("Allocation Tread: {0}", Thread.CurrentThread.ManagedThreadId));
             if (box.Width == 0 || box.Height == 0)
             {
                 Debug.WriteLine("minimized");
@@ -1354,7 +1354,7 @@
             }
             else
             {
-                if (_isSelected || DisableAltForSelection)
+                if ((_isSelected || DisableAltForSelection) && MouseWheelZoomEnabled)
                 {
                     _selectionEnd = FromLocalToLatLng((int)e.X, (int)e.Y);
                     {
@@ -1562,7 +1562,7 @@
 
             if (IsRotated)
             {
-                System.Drawing.Point[] tt = new System.Drawing.Point[] { new System.Drawing.Point(x, y) };
+                Point[] tt = new Point[] { new Point(x, y) };
                 rotationMatrixInvert.TransformPoints(tt);
                 var f = tt[0];
 
@@ -1590,7 +1590,7 @@
 
             if (IsRotated)
             {
-                System.Drawing.Point[] tt = new System.Drawing.Point[] { new System.Drawing.Point((int)ret.X, (int)ret.Y) };
+                Point[] tt = new Point[] { new Point((int)ret.X, (int)ret.Y) };
                 rotationMatrix.TransformPoints(tt);
                 var f = tt[0];
 


### PR DESCRIPTION
### Description of Change ###

Mapped selected area and zoom enable/disable property.

### Bugs Fixed ###

- Now can disable Map zom.

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
