### PR TITLE
Fixed incorrect group header renderer

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/ListView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/ListView.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.GTK.Cells;
 using Xamarin.Forms.Platform.GTK.Extensions;
 
@@ -528,6 +529,12 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 
         private void MarkCellAsSelected(CellBase cell)
         {
+            if (cell == null)
+                return;
+
+            if (cell.Cell.GetIsGroupHeader<ItemsView<Cell>, Cell>())
+                return;
+
             foreach (var childCell in _list.Children.OfType<CellBase>())
             {
                 bool isTargetCell = cell == childCell;
@@ -544,7 +551,10 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 
         private void SelectionColorUpdated()
         {
-            _selectedCell?.ModifyBg(StateType.Normal, _selectionColor);
+            if (_selectedCell == null)
+                return;
+
+            _selectedCell.ModifyBg(StateType.Normal, _selectionColor);
         }
     }
 }

--- a/Xamarin.Forms.Platform.GTK/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ListViewRenderer.cs
@@ -374,7 +374,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
                     if (group.Count != 0)
                     {
-                        if (group.HeaderContent != null)
+                        if (HasHeader(group))
                             _cells.Add(GetCell(group.HeaderContent));
                         else
                             _cells.Add(CreateEmptyHeader());
@@ -390,6 +390,21 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
                 _listView.Items = _cells;
             }
+        }
+
+        private bool HasHeader(ITemplatedItemsList<Cell> group)
+        {
+            if (Element == null)
+                return false;
+
+            if (group.HeaderContent != null &&
+                Element.GroupShortNameBinding != null ||
+                Element.GroupHeaderTemplate != null)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private Cells.TextCell CreateEmptyHeader()


### PR DESCRIPTION
### Description of Change ###

Changes in ListView renderer and groups validations.

### Bugs Fixed ###

- Fixed incorrect group header renderer.

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
