### PR TITLE
Removed static Platform toolbar tracker

### DIFF
--- a/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
@@ -71,16 +71,6 @@ namespace Xamarin.Forms.Platform.GTK
             }
         }
 
-        public Gdk.Size GetCurrentToolbarSize()
-        {
-            if (Toolbar?.Visible != true)
-            {
-                return Gdk.Size.Empty;
-            }
-
-            return Toolbar.Allocation.Size;
-        }
-
         public void UpdateIcon()
         {
             if (_toolbar == null || _navigation == null)

--- a/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.GTK.Controls;
 using Xamarin.Forms.Platform.GTK.Extensions;
+using Xamarin.Forms.Platform.GTK.Renderers;
 
 namespace Xamarin.Forms.Platform.GTK
 {
@@ -212,12 +213,12 @@ namespace Xamarin.Forms.Platform.GTK
                 return;
             }
 
-            var page = pageRenderer?.Container?.Child as Controls.Page;
+            var page = pageRenderer as IPageControl;
 
-            if (page != null)
+            if (page?.Control != null)
             {
-                page.Toolbar = _toolbar;
-                UpdateBarBackgroundColor(page);
+                page.Control.Toolbar = _toolbar;
+                UpdateBarBackgroundColor(page.Control);
             }
         }
 

--- a/Xamarin.Forms.Platform.GTK/Platform.cs
+++ b/Xamarin.Forms.Platform.GTK/Platform.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
-using Xamarin.Forms.Platform.GTK.Extensions;
 using Xamarin.Forms.Platform.GTK.Helpers;
 using Xamarin.Forms.Platform.GTK.Renderers;
 
@@ -197,9 +196,32 @@ namespace Xamarin.Forms.Platform.GTK
                 }
 
                 DisposeModelAndChildrenRenderers(modal);
+                RestoreToolbar();
             });
 
             return Task.FromResult<Page>(modal);
+        }
+
+        private void RestoreToolbar()
+        {
+            if (_modals.Any())
+            {
+                NativeToolbarTracker.Navigation = _modals.Last() as NavigationPage;
+            }
+            else
+            {
+                var mainPage = Application.Current.MainPage;
+
+                if (mainPage is MasterDetailPage)
+                {
+                    var masterDetailPage = mainPage as MasterDetailPage;
+                    NativeToolbarTracker.Navigation = masterDetailPage.Detail as NavigationPage;
+                }
+                else
+                {
+                    NativeToolbarTracker.Navigation = mainPage as NavigationPage;
+                }
+            }
         }
 
         Task INavigation.PopToRootAsync()

--- a/Xamarin.Forms.Platform.GTK/Platform.cs
+++ b/Xamarin.Forms.Platform.GTK/Platform.cs
@@ -27,8 +27,6 @@ namespace Xamarin.Forms.Platform.GTK
 
         internal PlatformRenderer PlatformRenderer => _renderer;
 
-        internal static GtkToolbarTracker NativeToolbarTracker = new GtkToolbarTracker();
-
         Page Page { get; set; }
 
         IReadOnlyList<Page> INavigation.ModalStack
@@ -196,32 +194,9 @@ namespace Xamarin.Forms.Platform.GTK
                 }
 
                 DisposeModelAndChildrenRenderers(modal);
-                RestoreToolbar();
             });
 
             return Task.FromResult<Page>(modal);
-        }
-
-        private void RestoreToolbar()
-        {
-            if (_modals.Any())
-            {
-                NativeToolbarTracker.Navigation = _modals.Last() as NavigationPage;
-            }
-            else
-            {
-                var mainPage = Application.Current.MainPage;
-
-                if (mainPage is MasterDetailPage)
-                {
-                    var masterDetailPage = mainPage as MasterDetailPage;
-                    NativeToolbarTracker.Navigation = masterDetailPage.Detail as NavigationPage;
-                }
-                else
-                {
-                    NativeToolbarTracker.Navigation = mainPage as NavigationPage;
-                }
-            }
         }
 
         Task INavigation.PopToRootAsync()

--- a/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
@@ -211,27 +211,12 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 UpdateBackgroundColor();
             else if (e.PropertyName == Xamarin.Forms.Page.BackgroundImageProperty.PropertyName)
                 UpdateBackgroundImage();
-            else if (e.PropertyName == Xamarin.Forms.Page.TitleProperty.PropertyName)
-                UpdateTitle();
-            else if (e.PropertyName == Xamarin.Forms.Page.IconProperty.PropertyName)
-                UpdateIcon();
         }
 
-        private void SetPageSize(int width, int height)
+        protected virtual void SetPageSize(int width, int height)
         {
-            var toolbarSize = Platform.NativeToolbarTracker.GetCurrentToolbarSize();
-            var pageContentSize = new Gdk.Rectangle(0, 0, width, height - toolbarSize.Height);
+            var pageContentSize = new Gdk.Rectangle(0, 0, width, height);
             SetElementSize(pageContentSize.ToSize());
-        }
-
-        private void UpdateTitle()
-        {
-            Platform.NativeToolbarTracker.UpdateTitle();
-        }
-
-        private void UpdateIcon()
-        {
-            Platform.NativeToolbarTracker.UpdateIcon();
         }
     }
 }

--- a/Xamarin.Forms.Platform.GTK/Renderers/IToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/IToolbarTracker.cs
@@ -1,0 +1,7 @@
+﻿namespace Xamarin.Forms.Platform.GTK.Renderers
+{
+    public interface IToolbarTracker
+    {
+        GtkToolbarTracker NativeToolbarTracker { get; }
+    }
+}

--- a/Xamarin.Forms.Platform.GTK/Renderers/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/MasterDetailPageRenderer.cs
@@ -148,7 +148,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
         private void UpdateBarTextColor()
         {
-            var navigationPage = Platform.NativeToolbarTracker.Navigation;
+            var navigationPage = Page.Detail as NavigationPage;
 
             if (navigationPage != null)
             {
@@ -160,7 +160,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
         private void UpdateBarBackgroundColor()
         {
-            var navigationPage = Platform.NativeToolbarTracker.Navigation;
+            var navigationPage = Page.Detail as NavigationPage;
 
             if (navigationPage != null)
             {
@@ -181,7 +181,13 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 var image = await handler.LoadImageAsync(hamburguerIcon);
                 Widget.UpdateHamburguerIcon(image);
 
-                Platform.NativeToolbarTracker.UpdateToolBar();
+                var navigationPage = Page.Detail as NavigationPage;
+
+                if (navigationPage != null)
+                {
+                    var navigationRenderer = Platform.GetRenderer(navigationPage) as IToolbarTracker;
+                    navigationRenderer?.NativeToolbarTracker.UpdateToolBar();
+                }
             }
         }
 

--- a/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
@@ -89,7 +89,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 return;
 
             _toolbarTracker.TryHide(Page);
-            //Platform.NativeToolbarTracker.TryHide(Page);
             _appeared = false;
 
             PageController?.SendDisappearing();
@@ -203,7 +202,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 throw new InvalidOperationException(
                     "NavigationPage must have a root Page before being used. Either call PushAsync with a valid Page, or pass a Page to the constructor before usage.");
 
-            //Platform.NativeToolbarTracker.Navigation = Page;
             _toolbarTracker.Navigation = Page;
             _currentPage = Page.CurrentPage;
             UpdateCurrentPage();
@@ -479,7 +477,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             var backButton = Page.OnThisPlatform().GetBackButtonIcon();
 
             _toolbarTracker.UpdateBackButton(backButton);
-            //Platform.NativeToolbarTracker.UpdateBackButton(backButton);
             UpdateToolBar();
         }
 
@@ -507,7 +504,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             GLib.Timeout.Add(0, () =>
             {
                 _toolbarTracker.UpdateToolBar();
-                //Platform.NativeToolbarTracker.UpdateToolBar();
                 return false;
             });
         }

--- a/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
@@ -60,8 +60,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
         protected override void OnShown()
         {
-            Platform.NativeToolbarTracker.Navigation = Page;
-
             if (_appeared)
                 return;
 

--- a/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
@@ -177,6 +177,12 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             Container.IsFocus = true;
         }
 
+        protected override void SetPageSize(int width, int height)
+        {
+            var pageContentSize = new Gdk.Rectangle(0, 0, width, height - GtkToolbarConstants.ToolbarHeight);
+            SetElementSize(pageContentSize.ToSize());
+        }
+
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             base.OnElementPropertyChanged(sender, e);
@@ -478,12 +484,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
             _toolbarTracker.UpdateBackButton(backButton);
             UpdateToolBar();
-        }
-
-        protected override void SetPageSize(int width, int height)
-        {
-            var pageContentSize = new Gdk.Rectangle(0, 0, width, height - GtkToolbarConstants.ToolbarHeight);
-            SetElementSize(pageContentSize.ToSize());
         }
 
         private Task AnimatePageAsync(Container container, int from, int to)

--- a/Xamarin.Forms.Platform.GTK/Renderers/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/TabbedPageRenderer.cs
@@ -56,6 +56,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             UpdateBarTextColor();
             UpdateTabPos();
             UpdateBackgroundImage();
+
+            Platform.NativeToolbarTracker.Navigation = Page.CurrentPage as NavigationPage;
         }
 
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -276,6 +278,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
             if (currentSelectedChild != null)
             {
+                Platform.NativeToolbarTracker.Navigation = currentSelectedChild as NavigationPage;
                 ElementController.SetValueFromRenderer(TabbedPage.SelectedItemProperty, currentSelectedChild.BindingContext);
             }
         }

--- a/Xamarin.Forms.Platform.GTK/Renderers/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/TabbedPageRenderer.cs
@@ -56,8 +56,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             UpdateBarTextColor();
             UpdateTabPos();
             UpdateBackgroundImage();
-
-            Platform.NativeToolbarTracker.Navigation = Page.CurrentPage as NavigationPage;
         }
 
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -272,14 +270,16 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
         private void OnNotebookPageSwitched(object o, SwitchPageArgs args)
         {
             var currentPageIndex = (int)args.PageNum;
-            Element currentSelectedChild = Page.Children.Count > currentPageIndex
+            VisualElement currentSelectedChild = Page.Children.Count > currentPageIndex
                 ? Page.Children[currentPageIndex]
                 : null;
 
             if (currentSelectedChild != null)
             {
-                Platform.NativeToolbarTracker.Navigation = currentSelectedChild as NavigationPage;
                 ElementController.SetValueFromRenderer(TabbedPage.SelectedItemProperty, currentSelectedChild.BindingContext);
+
+                var pageRenderer = Platform.GetRenderer(currentSelectedChild);
+                pageRenderer?.Container.ShowAll();
             }
         }
     }

--- a/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
+++ b/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
@@ -179,6 +179,7 @@
     <Compile Include="Renderers\FrameRenderer.cs" />
     <Compile Include="Renderers\ImageRenderer.cs" />
     <Compile Include="Renderers\IPageControl.cs" />
+    <Compile Include="Renderers\IToolbarTracker.cs" />
     <Compile Include="Renderers\LabelRenderer.cs" />
     <Compile Include="Renderers\LayoutRenderer.cs" />
     <Compile Include="Renderers\ListViewRenderer.cs" />


### PR DESCRIPTION
### Description of Change ###

Shared toolbar tracker has been removed from Platform class, as each NavigationPage should manage its own tracker to allow multiple independent instances running at the same time in a page.

### Bugs Fixed ###

- Fixes bug G1461: when going back no navigation bar is shown.

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
