### PR TITLE
Gtk header footer size fix

### DIFF
--- a/Xamarin.Forms.Platform.GTK/FormsWindow.cs
+++ b/Xamarin.Forms.Platform.GTK/FormsWindow.cs
@@ -16,12 +16,14 @@ namespace Xamarin.Forms.Platform.GTK
             SetSizeRequest(400, 400);
 
             MainThreadID = Thread.CurrentThread.ManagedThreadId;
+            MainWindow = this;
 
             if (SynchronizationContext.Current == null)
                 SynchronizationContext.SetSynchronizationContext(new GtkSynchronizationContext());
         }
 
         public static int MainThreadID { get; set; }
+        public static Window MainWindow { get; set; }
 
         public void LoadApplication(Application application)
         {

--- a/Xamarin.Forms.Platform.GTK/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ListViewRenderer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
-using Gtk;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.GTK.Cells;
 using Xamarin.Forms.Platform.GTK.Extensions;
@@ -173,16 +172,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                 {
                     cell.WidthRequest = _lastAllocation.Width;
                     cell.QueueDraw();
-                }
-
-                if (Controller.HeaderElement != null)
-                {
-                    UpdateHeader();
-                }
-
-                if (Controller.FooterElement != null)
-                {
-                    UpdateFooter();
                 }
             }
         }


### PR DESCRIPTION
### Description of Change ###

Gtk header footer size fix.

### Bugs Fixed ###

- Gtk header footer size fix.

### API Changes ###

List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
