### PR TITLE
Queue layout resize when a LayoutChanged event is raised

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Renderers/LayoutRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/LayoutRenderer.cs
@@ -10,6 +10,11 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
         protected override void OnElementChanged(ElementChangedEventArgs<Layout> e)
         {
+            if (e.OldElement != null)
+            {
+                e.OldElement.LayoutChanged -= LayoutChanged;
+            }
+
             if (e.NewElement != null)
             {
                 if (Control == null)
@@ -24,6 +29,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
                     SetNativeControl(_fixed);
                 }
 
+                e.NewElement.LayoutChanged += LayoutChanged;
+
                 if (_packager == null)
                 {
                     _packager = new LayoutElementPackager(this);
@@ -33,6 +40,24 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             }
 
             base.OnElementChanged(e);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (Element != null)
+                {
+                    Element.LayoutChanged -= LayoutChanged;
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private void LayoutChanged(object sender, System.EventArgs e)
+        {
+            QueueResize();
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

Queue layout resize when a LayoutChanged event is raised.

### Bugs Fixed ###

- When elements are initially hidden, and before page load they are shown, layout positioning is not properly applied.

### API Changes ###

None.

### Behavioral Changes ###

None.

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
