### PR TITLE
Toolbar size and page rendering

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/Page.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/Page.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
         private Gdk.Rectangle _lastAllocation = Gdk.Rectangle.Zero;
         private EventBox _headerContainer;
         private EventBox _contentContainerWrapper;
-        private Fixed _contentContainer;
+        private Table _contentContainer;
         private HBox _toolbar;
         private EventBox _content;
         private ImageControl _image;
@@ -93,24 +93,6 @@ namespace Xamarin.Forms.Platform.GTK.Controls
             }
         }
 
-        protected override void OnSizeAllocated(Gdk.Rectangle allocation)
-        {
-            base.OnSizeAllocated(allocation);
-
-            if (_lastAllocation != allocation)
-            {
-                _lastAllocation = allocation;
-
-                _image.SetSizeRequest(
-                    _contentContainer.Allocation.Width,
-                    _contentContainer.Allocation.Height);
-
-                _content.SetSizeRequest(
-                    _contentContainer.Allocation.Width,
-                    _contentContainer.Allocation.Height);
-            }
-        }
-
         private void BuildPage()
         {
             _defaultBackgroundColor = Style.Backgrounds[(int)StateType.Normal];
@@ -127,8 +109,8 @@ namespace Xamarin.Forms.Platform.GTK.Controls
             _image.Aspect = ImageAspect.Fill;
 
             _contentContainerWrapper = new EventBox();
-            _contentContainer = new Fixed();
-            _contentContainer.Add(_image);
+            _contentContainer = new Table(1, 1, true);
+            _contentContainer.Attach(_image, 0, 1, 0, 1);
             _contentContainerWrapper.Add(_contentContainer);
 
             root.PackStart(_contentContainerWrapper, true, true, 0); // Should fill all available space
@@ -150,7 +132,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
         {
             _contentContainer.RemoveFromContainer(_content);
             _content = newContent;
-            _contentContainer.Add(_content);
+            _contentContainer.Attach(_content, 0, 1, 0, 1);
             _content.ShowAll();
         }
     }

--- a/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
@@ -218,12 +218,14 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
         protected virtual void SetPageSize(int width, int height)
         {
-            if (Page != null && 
+            var finalHeight = height;
+
+            if (Page != null &&
                 Page.Parent is NavigationPage &&
                 NavigationPage.GetHasNavigationBar(Page))
-                height = height - GtkToolbarConstants.ToolbarHeight;
+                finalHeight -= GtkToolbarConstants.ToolbarHeight;
 
-            var pageContentSize = new Gdk.Rectangle(0, 0, width, height);
+            var pageContentSize = new Gdk.Rectangle(0, 0, width, finalHeight);
             SetElementSize(pageContentSize.ToSize());
         }
     }

--- a/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
@@ -178,12 +178,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
             Container.IsFocus = true;
         }
 
-        protected override void SetPageSize(int width, int height)
-        {
-            var pageContentSize = new Gdk.Rectangle(0, 0, width, height - GtkToolbarConstants.ToolbarHeight);
-            SetElementSize(pageContentSize.ToSize());
-        }
-
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             base.OnElementPropertyChanged(sender, e);


### PR DESCRIPTION
### Description of Change ###

Fix some issues with page rendering and toolbar size consideration for layout calculations.

### Bugs Fixed ###

- Movies sample: actor photo galleries were displaying a bottom empty space equivalent to toolbar size.

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
