### PR TITLE
Page renderer and size allocate loops

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/AbstractPageRenderer.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
         where TPage : Page
     {
         private Gdk.Rectangle _lastAllocation;
+        private DateTime _lastAllocationTime;
         protected bool _disposed;
         protected bool _appeared;
         protected readonly PropertyChangedEventHandler _propertyChangedHandler;
@@ -131,18 +132,19 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
         {
             base.OnSizeAllocated(allocation);
 
+            var now = DateTime.Now;
+            var diff = now.Subtract(_lastAllocationTime);
+
             if (_lastAllocation != allocation)
             {
                 _lastAllocation = allocation;
+                _lastAllocationTime = now;
                 SetPageSize(_lastAllocation.Width, _lastAllocation.Height);
                 PageQueueResize();
             }
-            else
+            else if (diff > TimeSpan.FromMilliseconds(50)) // Prevent infinite resizing loops for very fast layout changes
             {
-                Gtk.Application.Invoke(delegate
-                {
-                    SetPageSize(allocation.Width, allocation.Height);
-                });
+                SetPageSize(allocation.Width, allocation.Height);
             }
         }
 


### PR DESCRIPTION
### Description of Change ###

Prevents infinite resizing loops when there are very fast layout changes.

### Bugs Fixed ###

- Full size allocate calls in main thread provokes infinite loops in some cases, like in StackLayoutPageCode sample.

### API Changes ###

None

### Behavioral Changes ###

None

### PR Checklist ###

- [ ] Has tests (if omitted, state reason in description)
- [ ] Rebased on top of master at time of PR
- [ ] Changes adhere to coding standard
- [ ] Consolidate commits as makes sense
